### PR TITLE
Bump version to 2.2.0

### DIFF
--- a/lib/puppet/indirector/facts/puppetdb.rb
+++ b/lib/puppet/indirector/facts/puppetdb.rb
@@ -3,6 +3,7 @@ require 'puppet/node/facts'
 require 'puppet/indirector/rest'
 require 'puppet/util/puppetdb'
 require 'json'
+require 'time'
 
 class Puppet::Node::Facts::Puppetdb < Puppet::Indirector::REST
   include Puppet::Util::Puppetdb
@@ -13,23 +14,33 @@ class Puppet::Node::Facts::Puppetdb < Puppet::Indirector::REST
     Puppet::Util::Puppetdb::GlobalCheck.run
   end
 
+  def get_trusted_info(node)
+    trusted = Puppet.lookup(:trusted_information) do
+      Puppet::Context::TrustedInformation.local(request.node)
+    end
+    trusted.to_h
+  end
+
   def save(request)
     profile "facts#save" do
       payload = profile "Encode facts command submission payload" do
         facts = request.instance.dup
         facts.values = facts.strip_internal
-        facts.stringify
+        if Puppet[:trusted_node_data]
+          facts.values[:trusted] = get_trusted_info(request.node)
+        end
         {
           "name" => facts.name,
           "values" => facts.values,
           # PDB-453: we call to_s to avoid a 'stack level too deep' error
           # when we attempt to use ActiveSupport 2.3.16 on RHEL 5 with
           # legacy storeconfigs.
-          "environment" => request.environment.to_s,
+          "environment" => request.options[:environment] || request.environment.to_s,
+          "producer-timestamp" => request.options[:producer_timestamp] || Time.now.iso8601,
         }
       end
 
-      submit_command(request.key, payload, CommandReplaceFacts, 2)
+      submit_command(request.key, payload, CommandReplaceFacts, 3)
     end
   end
 

--- a/lib/puppetdb/terminus/version.rb
+++ b/lib/puppetdb/terminus/version.rb
@@ -1,5 +1,5 @@
 module PuppetDB
   module Terminus
-    VERSION = "2.1.0"
+    VERSION = "2.2.0"
   end
 end


### PR DESCRIPTION
Previous versions of the Terminus store facts as strings in PuppetDB.
This causes a problem when trying to migrate from `puppet apply` to
master/agent model where fact cache is used during catalogue
complication (things like `validate_hash()` fall over)

Fix was implemented via https://tickets.puppetlabs.com/browse/PDB-816
and first introduced in PuppetDB 2.2.0

@yasn77
