### PR TITLE
Move --strip-components earlier for mac compatibility

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -10,7 +10,7 @@ task :sync_with_upstream do
 
   `curl -sLO #{url}`
   FileUtils::rm_rf File.expand_path('../lib/puppet', __FILE__)
-  `tar -zxf #{archive} puppetdb-#{version}/puppet/lib/ --strip-components=2`
+  `tar --strip-components=2 -zxf #{archive} puppetdb-#{version}/puppet/lib/`
 end
 
 task :build => :sync_with_upstream


### PR DESCRIPTION
As currently written the rake task fails on mac:

```
$ rake sync_with_upstream
tar: --strip-components=2: Not found in archive
tar: Error exit delayed from previous errors.
```

This is a simple fix to put the `--strip-components` earlier in the command line, which works on both mac and linux.